### PR TITLE
Updated dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,6 @@ readme = "README.md"
 nightly = []
 
 [dependencies]
-bit-set = "0.2"
-bit-vec = "0.4"
-vec_map = "0.3"
+bit-set = "~0.5"
+bit-vec = "~0.5"
+vec_map = "~0.8"


### PR DESCRIPTION
Updated dependencies from …
```toml
bit-set = "0.2"
bit-vec = "0.4"
vec_map = "0.3"
```

… to …

```toml
bit-set = "~0.5"
bit-vec = "~0.5"
vec_map = "~0.8"
```

While doing so I also changed from strict (`"…"`) to compatibility (`"~…"`) pinning,
as the former was causing conflicts for [deepthought/vectors](https://github.com/deepthought/vectors) as of recently.