### PR TITLE
Bump bit-vec to ~0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,5 @@ nightly = []
 
 [dependencies]
 bit-set = "~0.5"
-bit-vec = "~0.5"
+bit-vec = "~0.6"
 vec_map = "~0.8"


### PR DESCRIPTION
This fixes the following compilation error:

```
error[E0277]: the trait bound `B: bit_vec::BitBlock` is not satisfied
   --> src/lib.rs:285:32
    |
285 | impl<'a, B: bit_vec::BitBlock> OrderedSetIterator for bit_set::Iter<'a, B> {}
    |                                ^^^^^^^^^^^^^^^^^^ the trait `bit_vec::BitBlock` is not implemented for `B`
    |
help: consider further restricting this bound with `+ bit_vec::BitBlock`
   --> src/lib.rs:285:13
    |
285 | impl<'a, B: bit_vec::BitBlock> OrderedSetIterator for bit_set::Iter<'a, B> {}
    |             ^^^^^^^^^^^^^^^^^
    = note: required because of the requirements on the impl of `std::iter::Iterator` for `bit_set::Iter<'a, B>`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0277`.
error: could not compile `ordered_iter`.

To learn more, run the command again with --verbose.
```

which stems from having two different versions of `bit-vec` in the dependency tree.